### PR TITLE
refactor: refactor app/post index & settings pages to typescript

### DIFF
--- a/pages/app/post/[id]/index.tsx
+++ b/pages/app/post/[id]/index.tsx
@@ -1,13 +1,13 @@
 import Layout from "@/components/app/Layout";
 import useSWR from "swr";
 import { useDebounce } from "use-debounce";
-import { useState, useEffect, FormEvent } from "react";
+import { useState, useEffect, ChangeEvent } from "react";
 import TextareaAutosize from "react-textarea-autosize";
 import { useRouter } from "next/router";
 import LoadingDots from "@/components/app/loading-dots";
 import Loader from "@/components/app/Loader";
 import { fetcher } from "@/lib/fetcher"
-import type { Site } from ".prisma/client";
+import type { Post, Site } from ".prisma/client";
 
 interface PostData {
   title: string;
@@ -15,14 +15,7 @@ interface PostData {
   content: string;
 }
 
-interface PostWithSite {
-  title: string | null;
-  description: string | null;
-  content: string | null;
-  slug: string;
-  updatedAt: Date;
-  published: boolean;
-  siteId: string | null;
+interface PostWithSite extends Post {
   site: Site | null;
 }
 
@@ -156,18 +149,18 @@ export default function Post() {
 
   return (
     <>
-      <Layout siteId={post?.siteId ?? undefined}>
+      <Layout siteId={post?.site?.id}>
         <div className="max-w-screen-xl mx-auto px-10 sm:px-20 mt-10 mb-16">
           <TextareaAutosize
             name="title"
-            onInput={(e: FormEvent<HTMLTextAreaElement>) => setData({ ...data, title: e.currentTarget.value })}
+            onInput={(e: ChangeEvent<HTMLTextAreaElement>) => setData({ ...data, title: e.currentTarget.value })}
             className="w-full px-2 py-4 text-gray-800 placeholder-gray-400 mt-6 text-5xl font-cal resize-none border-none focus:outline-none focus:ring-0"
             placeholder="Untitled Post"
             value={data.title}
           />
           <TextareaAutosize
             name="description"
-            onInput={(e: FormEvent<HTMLTextAreaElement>) => setData({ ...data, description: e.currentTarget.value })}
+            onInput={(e: ChangeEvent<HTMLTextAreaElement>) => setData({ ...data, description: e.currentTarget.value })}
             className="w-full px-2 py-3 text-gray-800 placeholder-gray-400 text-xl mb-3 resize-none border-none focus:outline-none focus:ring-0"
             placeholder="No description provided. Click to edit."
             value={data.description}
@@ -183,7 +176,7 @@ export default function Post() {
           </div>
           <TextareaAutosize
             name="content"
-            onInput={(e: FormEvent<HTMLTextAreaElement>) => setData({ ...data, content: e.currentTarget.value })}
+            onInput={(e: ChangeEvent<HTMLTextAreaElement>) => setData({ ...data, content: e.currentTarget.value })}
             className="w-full px-2 py-3 text-gray-800 placeholder-gray-400 text-lg mb-5 resize-none border-none focus:outline-none focus:ring-0"
             placeholder={`Write some content. Markdown supported:
 

--- a/pages/app/post/[id]/index.tsx
+++ b/pages/app/post/[id]/index.tsx
@@ -1,19 +1,37 @@
 import Layout from "@/components/app/Layout";
 import useSWR from "swr";
 import { useDebounce } from "use-debounce";
-import { useState, useEffect } from "react";
+import { useState, useEffect, FormEvent } from "react";
 import TextareaAutosize from "react-textarea-autosize";
 import { useRouter } from "next/router";
 import LoadingDots from "@/components/app/loading-dots";
 import Loader from "@/components/app/Loader";
 import { fetcher } from "@/lib/fetcher"
+import type { Site } from ".prisma/client";
+
+interface PostData {
+  title: string;
+  description: string;
+  content: string;
+}
+
+interface PostWithSite {
+  title: string | null;
+  description: string | null;
+  content: string | null;
+  slug: string;
+  updatedAt: Date;
+  published: boolean;
+  siteId: string | null;
+  site: Site | null;
+}
 
 export default function Post() {
   const router = useRouter();
   const { id } = router.query;
   const postId = id;
 
-  const { data: post, isValidating } = useSWR(
+  const { data: post, isValidating } = useSWR<PostWithSite>(
     `/api/post?postId=${postId}`,
     fetcher,
     {
@@ -27,17 +45,17 @@ export default function Post() {
   const [savedState, setSavedState] = useState(
     post
       ? `Last saved at ${Intl.DateTimeFormat("en", { month: "short" }).format(
-          new Date(post.updatedAt)
-        )} ${Intl.DateTimeFormat("en", { day: "2-digit" }).format(
-          new Date(post.updatedAt)
-        )} ${Intl.DateTimeFormat("en", {
-          hour: "numeric",
-          minute: "numeric",
-        }).format(new Date(post.updatedAt))}`
+        new Date(post.updatedAt)
+      )} ${Intl.DateTimeFormat("en", { day: "2-digit" }).format(
+        new Date(post.updatedAt)
+      )} ${Intl.DateTimeFormat("en", {
+        hour: "numeric",
+        minute: "numeric",
+      }).format(new Date(post.updatedAt))}`
       : "Saving changes..."
   );
 
-  const [data, setData] = useState({
+  const [data, setData] = useState<PostData>({
     title: "",
     description: "",
     content: "",
@@ -45,9 +63,9 @@ export default function Post() {
   useEffect(() => {
     if (post)
       setData({
-        title: post.title,
-        description: post.description,
-        content: post.content,
+        title: post.title ?? "",
+        description: post.description ?? "",
+        content: post.content ?? "",
       });
   }, [post]);
   const [debouncedData] = useDebounce(data, 1000);
@@ -66,7 +84,7 @@ export default function Post() {
   }, [publishing, data]);
 
   useEffect(() => {
-    const clickedSave = (e) => {
+    const clickedSave = (e: KeyboardEvent) => {
       let charCode = String.fromCharCode(e.which).toLowerCase();
       if ((e.ctrlKey || e.metaKey) && charCode === "s") {
         e.preventDefault();
@@ -79,7 +97,7 @@ export default function Post() {
     };
   }, [data]);
 
-  async function saveChanges(data) {
+  async function saveChanges(data: PostData) {
     setSavedState("Saving changes...");
     const response = await fetch("/api/post", {
       method: "PUT",
@@ -126,7 +144,7 @@ export default function Post() {
       }),
     });
     await response.json();
-    router.push(`https://${post.site.subdomain}.vercel.pub/${post.slug}`);
+    router.push(`https://${post?.site?.subdomain}.vercel.pub/${post?.slug}`);
   };
 
   if (isValidating)
@@ -138,18 +156,18 @@ export default function Post() {
 
   return (
     <>
-      <Layout siteId={post?.site.id}>
+      <Layout siteId={post?.siteId ?? undefined}>
         <div className="max-w-screen-xl mx-auto px-10 sm:px-20 mt-10 mb-16">
           <TextareaAutosize
             name="title"
-            onInput={(e) => setData({ ...data, title: e.target.value })}
+            onInput={(e: FormEvent<HTMLTextAreaElement>) => setData({ ...data, title: e.currentTarget.value })}
             className="w-full px-2 py-4 text-gray-800 placeholder-gray-400 mt-6 text-5xl font-cal resize-none border-none focus:outline-none focus:ring-0"
             placeholder="Untitled Post"
             value={data.title}
           />
           <TextareaAutosize
             name="description"
-            onInput={(e) => setData({ ...data, description: e.target.value })}
+            onInput={(e: FormEvent<HTMLTextAreaElement>) => setData({ ...data, description: e.currentTarget.value })}
             className="w-full px-2 py-3 text-gray-800 placeholder-gray-400 text-xl mb-3 resize-none border-none focus:outline-none focus:ring-0"
             placeholder="No description provided. Click to edit."
             value={data.description}
@@ -165,7 +183,7 @@ export default function Post() {
           </div>
           <TextareaAutosize
             name="content"
-            onInput={(e) => setData({ ...data, content: e.target.value })}
+            onInput={(e: FormEvent<HTMLTextAreaElement>) => setData({ ...data, content: e.currentTarget.value })}
             className="w-full px-2 py-3 text-gray-800 placeholder-gray-400 text-lg mb-5 resize-none border-none focus:outline-none focus:ring-0"
             placeholder={`Write some content. Markdown supported:
 
@@ -218,11 +236,10 @@ Ordered lists look like:
                   : "Publish"
               }
               disabled={disabled}
-              className={`${
-                disabled
+              className={`${disabled
                   ? "cursor-not-allowed bg-gray-300 border-gray-300"
                   : "bg-black hover:bg-white hover:text-black border-black"
-              } mx-2 w-32 h-12 text-lg text-white border-2 focus:outline-none transition-all ease-in-out duration-150`}
+                } mx-2 w-32 h-12 text-lg text-white border-2 focus:outline-none transition-all ease-in-out duration-150`}
             >
               {publishing ? <LoadingDots /> : "Publish  →"}
             </button>

--- a/pages/app/post/[id]/settings.tsx
+++ b/pages/app/post/[id]/settings.tsx
@@ -5,7 +5,7 @@ import CloudinaryUploadWidget from "@/components/Cloudinary";
 import LoadingDots from "@/components/app/loading-dots";
 import saveImage from "@/lib/save-image";
 import Modal from "@/components/Modal";
-import { useState, useEffect, FormEvent } from "react";
+import { useState, useEffect, ChangeEvent } from "react";
 import { useRouter } from "next/router";
 import Loader from "@/components/app/Loader";
 import toast, { Toaster } from "react-hot-toast";
@@ -19,18 +19,7 @@ interface PostSettings {
   imageBlurhash: string;
 }
 
-interface PostWithSite {
-  id: string;
-  title: string | null;
-  description: string | null;
-  content: string | null;
-  slug: string;
-  image: string | null;
-  imageBlurhash: string | null;
-  createdAt: Date;
-  updatedAt: Date;
-  published: boolean;
-  siteId: string | null;
+interface PostWithSite extends Post {
   site: Site | null;
 }
 
@@ -110,7 +99,7 @@ export default function PostSettings() {
 
   return (
     <>
-      <Layout siteId={settings?.siteId ?? ""}>
+      <Layout siteId={settings?.site?.id}>
         <Toaster
           position="top-right"
           toastOptions={{
@@ -132,8 +121,8 @@ export default function PostSettings() {
                   name="slug"
                   placeholder="post-slug"
                   value={data?.slug}
-                  onInput={(e: FormEvent<HTMLInputElement>) =>
-                    setData((data) => ({ ...data, slug: e.currentTarget.value }))
+                  onInput={(e: ChangeEvent<HTMLInputElement>) =>
+                    setData((data) => ({ ...data, slug: e.target.value }))
                   }
                 />
               </div>

--- a/pages/app/post/[id]/settings.tsx
+++ b/pages/app/post/[id]/settings.tsx
@@ -5,18 +5,41 @@ import CloudinaryUploadWidget from "@/components/Cloudinary";
 import LoadingDots from "@/components/app/loading-dots";
 import saveImage from "@/lib/save-image";
 import Modal from "@/components/Modal";
-import { useState, useEffect } from "react";
+import { useState, useEffect, FormEvent } from "react";
 import { useRouter } from "next/router";
 import Loader from "@/components/app/Loader";
 import toast, { Toaster } from "react-hot-toast";
 import { fetcher } from "@/lib/fetcher"
+import { Post, Site } from '@prisma/client';
+
+interface PostSettings {
+  slug: string;
+  id: string;
+  image: string;
+  imageBlurhash: string;
+}
+
+interface PostWithSite {
+  id: string;
+  title: string | null;
+  description: string | null;
+  content: string | null;
+  slug: string;
+  image: string | null;
+  imageBlurhash: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  published: boolean;
+  siteId: string | null;
+  site: Site | null;
+}
 
 export default function PostSettings() {
   const router = useRouter();
   const { id } = router.query;
-  const postId = id;
+  const postId: string = id as string;
 
-  const { data: settings, isValidating } = useSWR(
+  const { data: settings, isValidating } = useSWR<PostWithSite>(
     `/api/post?postId=${postId}`,
     fetcher,
     {
@@ -31,21 +54,24 @@ export default function PostSettings() {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [deletingPost, setDeletingPost] = useState(false);
 
-  const [data, setData] = useState({
-    image: settings?.image,
-    imageBlurhash: settings?.imageBlurhash,
+  const [data, setData] = useState<PostSettings>({
+    image: settings?.image ?? "",
+    imageBlurhash: settings?.imageBlurhash ?? "",
+    slug: settings?.slug ?? "",
+    id: settings?.id ?? "",
   });
 
   useEffect(() => {
     if (settings)
       setData({
         slug: settings.slug,
-        image: settings.image,
-        imageBlurhash: settings.imageBlurhash,
+        image: settings.image ?? "",
+        imageBlurhash: settings.imageBlurhash ?? "",
+        id: settings.id,
       });
   }, [settings]);
 
-  async function savePostSettings(data) {
+  async function savePostSettings(data: PostSettings) {
     setSaving(true);
     const response = await fetch("/api/post", {
       method: "PUT",
@@ -65,13 +91,13 @@ export default function PostSettings() {
     }
   }
 
-  async function deletePost(postId) {
+  async function deletePost(postId: string) {
     setDeletingPost(true);
     const response = await fetch(`/api/post?postId=${postId}`, {
       method: "DELETE",
     });
     if (response.ok) {
-      router.push(`/site/${settings.site.id}`);
+      router.push(`/site/${settings?.site?.id}`);
     }
   }
 
@@ -84,7 +110,7 @@ export default function PostSettings() {
 
   return (
     <>
-      <Layout siteId={settings?.site.id}>
+      <Layout siteId={settings?.siteId ?? ""}>
         <Toaster
           position="top-right"
           toastOptions={{
@@ -98,7 +124,7 @@ export default function PostSettings() {
               <h2 className="font-cal text-2xl">Post Slug</h2>
               <div className="border border-gray-700 rounded-lg flex items-center max-w-lg">
                 <span className="px-5 font-cal rounded-l-lg border-r border-gray-600">
-                  {settings?.site.subdomain}.vercel.pub/
+                  {settings?.site?.subdomain}.vercel.pub/
                 </span>
                 <input
                   className="w-full px-5 py-3 font-cal text-gray-700 bg-white border-none focus:outline-none focus:ring-0 rounded-none rounded-r-lg placeholder-gray-400"
@@ -106,8 +132,8 @@ export default function PostSettings() {
                   name="slug"
                   placeholder="post-slug"
                   value={data?.slug}
-                  onInput={(e) =>
-                    setData((data) => ({ ...data, slug: e.target.value }))
+                  onInput={(e: FormEvent<HTMLInputElement>) =>
+                    setData((data) => ({ ...data, slug: e.currentTarget.value }))
                   }
                 />
               </div>
@@ -115,9 +141,8 @@ export default function PostSettings() {
             <div className="space-y-6">
               <h2 className="font-cal text-2xl">Thumbnail Image</h2>
               <div
-                className={`${
-                  data.image ? "" : "animate-pulse bg-gray-300 h-150"
-                } relative mt-5 w-full border-2 border-gray-800 border-dashed rounded-md`}
+                className={`${data.image ? "" : "animate-pulse bg-gray-300 h-150"
+                  } relative mt-5 w-full border-2 border-gray-800 border-dashed rounded-md`}
               >
                 <CloudinaryUploadWidget
                   callback={(e) => saveImage(e, data, setData)}
@@ -202,11 +227,10 @@ export default function PostSettings() {
               <button
                 type="submit"
                 disabled={deletingPost}
-                className={`${
-                  deletingPost
+                className={`${deletingPost
                     ? "cursor-not-allowed text-gray-400 bg-gray-50"
                     : "bg-white text-gray-600 hover:text-black"
-                } w-full px-5 py-5 text-sm border-t border-l border-gray-300 rounded-br focus:outline-none focus:ring-0 transition-all ease-in-out duration-150`}
+                  } w-full px-5 py-5 text-sm border-t border-l border-gray-300 rounded-br focus:outline-none focus:ring-0 transition-all ease-in-out duration-150`}
               >
                 {deletingPost ? <LoadingDots /> : "DELETE POST"}
               </button>
@@ -220,11 +244,10 @@ export default function PostSettings() {
                 savePostSettings(data);
               }}
               disabled={saving}
-              className={`${
-                saving
+              className={`${saving
                   ? "cursor-not-allowed bg-gray-300 border-gray-300"
                   : "bg-black hover:bg-white hover:text-black border-black"
-              } mx-2 w-36 h-12 text-lg text-white border-2 focus:outline-none transition-all ease-in-out duration-150`}
+                } mx-2 w-36 h-12 text-lg text-white border-2 focus:outline-none transition-all ease-in-out duration-150`}
             >
               {saving ? <LoadingDots /> : "Save Changes"}
             </button>


### PR DESCRIPTION
This PR migrates the `pages/app/post/[id]/index.js` & `pages/app/post/[id]/settings.js` to Typescript. Based on advice [here](https://www.prisma.io/docs/concepts/components/prisma-client/advanced-type-safety/operating-against-partial-structures-of-model-types), I created the `PostWithSite` interface to allow us to access the types for the Site. This is currently more or less duplicated between the two files as I didn't see a clear place to dedupe. 