### PR TITLE
bug: Remove leaked Post type from prisma client

### DIFF
--- a/pages/app/post/[id]/index.tsx
+++ b/pages/app/post/[id]/index.tsx
@@ -11,7 +11,6 @@ import { fetcher } from "@/lib/fetcher";
 import { HttpMethod } from "@/types";
 
 import type { ChangeEvent } from "react";
-import type { Post } from ".prisma/client";
 
 import type { WithSitePost } from "@/types";
 


### PR DESCRIPTION
Removed the leaky type causing the post pages to fail. cc @NuroDev 